### PR TITLE
Add support for symmetric woodbury matrices

### DIFF
--- a/src/SymWoodburyMatrices.jl
+++ b/src/SymWoodburyMatrices.jl
@@ -1,0 +1,166 @@
+import Base:+,*,-,\,^,sparse,full
+
+VectorTypes = Union{AbstractMatrix, Vector, SubArray}
+
+using Base.LinAlg.BLAS:gemm!,gemm
+
+"""
+Represents a matrix of the form A + BDBᵀ.
+"""
+type SymWoodbury{T,AType, BType, DType} <: AbstractMatrix{T}
+
+  A::AType; 
+  B::BType; 
+  D::DType;
+
+end
+
+"""
+    SymWoodbury(A, B, D)
+
+Represents a matrix of the form A + BDBᵀ.
+"""
+function SymWoodbury{T}(A, B::AbstractMatrix{T}, D)
+    n = size(A, 1)
+    k = size(B, 2)
+    if size(A, 2) != n || size(B, 1) != n || size(D,1) != k || size(D,2) != k
+        throw(DimensionMismatch("Sizes of B ($(size(B))) and/or D ($(size(D))) are inconsistent with A ($(size(A)))"))
+    end
+    SymWoodbury{T, typeof(A),typeof(B),typeof(D)}(A,B,D)
+end
+
+function calc_inv(A, B, D)
+
+  W = inv(A);
+  X = W*B;
+  invD = -inv(D);
+  Z = inv(invD - B'*X);
+  SymWoodbury(W,X,Z);
+
+end
+
+Base.inv{T<:Any, AType<:Any, BType<:Any, DType<:Matrix}(O::SymWoodbury{T,AType,BType,DType}) = 
+  calc_inv(O.A, O.B, O.D)
+
+# D is typically small, so this is acceptable. 
+Base.inv{T<:Any, AType<:Any, BType<:Any, DType<:SparseMatrixCSC}(O::SymWoodbury{T,AType,BType,DType}) = 
+  calc_inv(O.A, O.B, full(O.D));
+
+\(W::SymWoodbury, R::StridedVecOrMat) = inv(W)*R
+
+"""
+    partialInv(O)
+
+Get the factors (X,Z) in W + XZXᵀ where W + XZXᵀ = inv( A + BDBᵀ )
+"""
+function partialInv(O::SymWoodbury)
+
+  if (size(O.B,2) == 0)
+    return (0,0)
+  end
+  X = (O.A)\O.B;
+  invD = -1*inv(O.D);
+  Z = inv(invD - O.B'*X);
+  return (X,Z);
+
+end
+
+function liftFactorVars(A,B,Di)
+  n  = size(A,1)
+  k  = size(B,2)
+  M = [A    B   ;
+       B'  -Di ];
+  M = lufact(M) # ldltfact once it's available.
+  return x -> (M\[x; zeros(k,1)])[1:n,:];
+end
+
+"""
+    liftFactor(A)
+
+More stable version of inv(A).  Returns a function which computs the inverse
+on evaluation, i.e. `liftFactor(A)(x)` is the same as `inv(A)*x`.
+"""
+liftFactor{T<:Any,
+           AType<:Any, 
+           BType<:Any, 
+           DType<:Matrix}(O::SymWoodbury{T,AType,BType,DType}) = 
+           liftFactorVars(sparse(O.A), sparse(O.B), sparse(inv(O.D))); 
+
+liftFactor{T<:Any,
+           AType<:Any, 
+           BType<:Any, 
+           DType<:SparseMatrixCSC}(O::SymWoodbury{T,AType,BType,DType}) = 
+           liftFactorVars(sparse(O.A), sparse(O.B), sparse(inv(full(O.D))));
+
+# Optimization - use specialized BLAS package 
+function *{T<:Any, AType<:Any, BType<:Matrix, DType<:Any}(O::SymWoodbury{T,AType,BType,DType}, 
+  x::Array{Float64,2})
+  o = O.A*x;
+  w = O.D*gemm('T','N',O.B,x);
+  gemm!('N','N',1.,O.B,w,1., o)
+  return o
+end
+
+function *{T<:Any, AType<:Any, BType<:Any, DType<:Any}(O::SymWoodbury{T,AType,BType,DType}, 
+  x::VectorTypes)
+  return O.A*x + O.B*(O.D*(O.B'x));
+end
+
+Base.Ac_mul_B(O1::SymWoodbury, x::VectorTypes) = O1*x
+
+PTypes = Union{AbstractMatrix}
+
++(O::SymWoodbury, M::SymWoodbury)    = SymWoodbury(O.A + M.A, [O.B M.B],
+                                                   cat([1,2],O.D,M.D) );
+*(α::Real, O::SymWoodbury)           = SymWoodbury(α*O.A, O.B, α*O.D);
+*(O::SymWoodbury, α::Real)           = SymWoodbury(α*O.A, O.B, α*O.D);
++(α::Real, O::SymWoodbury)           = α == 0 ?
+                                       SymWoodbury(O.A, O.B, O.D) :
+                                       SymWoodbury(O.A + α, O.B, O.D);
++(M::AbstractMatrix, O::SymWoodbury) = SymWoodbury(O.A + M, O.B, O.D);
++(O::SymWoodbury, M::PTypes)         = SymWoodbury(O.A + M, O.B, O.D);
+Base.size(M::SymWoodbury)            = size(M.A);
+Base.size(M::SymWoodbury, i)         = (i == 1 || i == 2) ? size(M)[1] : 1
+
+Base.full{T}(O::SymWoodbury{T})      = full(O.A) + O.B*O.D*O.B'
+
+function square(O::SymWoodbury)
+  A = O.A^2
+  D = O.D
+  B = O.B
+  Z = [(O.A*B + B) (O.A*B - B) B]
+  SymWoodbury(A, Z, full( cat([1,2],D/2,-D/2, D*B'*B*D) ) )
+end
+
+"""
+The product of two SymWoodbury matrices will generally be a Woodbury Matrix,
+except when they are the same, i.e. the user writes A'A or A*A' or A*A.
+
+Z(A + B*D*Bᵀ) = ZA + ZB*D*Bᵀ
+"""
+function *(O1::SymWoodbury, O2::SymWoodbury)
+  if (O1 === O2) 
+    return square(O1)
+  else
+    if O1.A == O2.A && O1.B == O2.B && O1.D == O2.D
+      return square(O1)
+    else
+      return Woodbury(O1*(O2.A), O1*(O2.B), O2.D, O2.B)
+    end
+  end
+end
+
+Base.Ac_mul_B(O1::SymWoodbury, O2::SymWoodbury) = O1*O2
+Base.A_mul_Bc(O1::SymWoodbury, O2::SymWoodbury) = O1*O2
+
+conjm(O::SymWoodbury, M) = SymWoodbury(M*O.A*M', M*O.B, O.D);
+
+Base.getindex(O::SymWoodbury, I::UnitRange, I2::UnitRange) =
+  SymWoodbury(O.A[I,I], O.B[I,:], O.D);
+
+# This is a slow hack, but generally these matrices aren't sparse.
+Base.sparse(O::SymWoodbury) = sparse(full(O))
+
+# returns a pointer to the original matrix, this is consistent with the
+# behavior of Symmetric in Base.
+Base.ctranspose(O::SymWoodbury) = O

--- a/src/WoodburyMatrices.jl
+++ b/src/WoodburyMatrices.jl
@@ -7,9 +7,11 @@ if VERSION < v"0.4.0-dev"
 end
 using Compat
 
+include("SymWoodburyMatrices.jl")
+
 import Base: *, \, A_ldiv_B!, convert, copy, det, full, show, similar, size
 
-export Woodbury
+export Woodbury, SymWoodbury, liftFactor
 
 #### Woodbury matrices ####
 @doc """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,3 +112,5 @@ for i in 1:5  # repeat 5 times
 
     @test maxabs(out - by_hand) == 0.0
 end
+
+include("runtests_sym.jl")

--- a/test/runtests_sym.jl
+++ b/test/runtests_sym.jl
@@ -1,0 +1,127 @@
+using Base.Test
+using WoodburyMatrices
+
+srand(123)
+n = 5
+
+for elty in (Float32, Float64, Complex64, Complex128, Int)
+
+    elty = Float64
+
+    a = rand(n); B = rand(n,2); D = rand(2,2); v = rand(n)
+
+    if elty == Int
+        v = rand(1:100, n)
+        a = rand(1:100, n, 2)
+        B = rand(1:100, 2, n)
+        D = rand(1:100, 2, 2)
+    else
+        v = convert(Vector{elty}, a)
+        a = convert(Vector{elty}, a)
+        B = convert(Matrix{elty}, B)
+        D = convert(Matrix{elty}, D)
+    end
+
+    ε = eps(abs2(float(one(elty))))
+    A = Diagonal(a)
+    
+    # Woodbury
+    W = SymWoodbury(A, B, D)
+    F = full(W)
+
+    @test_approx_eq (2*W)*v 2*(W*v)
+    @test_approx_eq W'*v W*v
+    @test_approx_eq (W'W)*v full(W)*(full(W)*v)
+    @test_approx_eq (W*W)*v full(W)*(full(W)*v)
+    @test_approx_eq (W*W')*v full(W)*(full(W)*v)
+    @test_approx_eq W[1:3,1:3]*v[1:3] full(W)[1:3,1:3]*v[1:3]
+
+    v = rand(n, 1)
+
+    @test_approx_eq (2*W)*v 2*(W*v)
+    @test_approx_eq (W'W)*v full(W)*(full(W)*v)
+    @test_approx_eq (W*W)*v full(W)*(full(W)*v)
+    @test_approx_eq (W*W')*v full(W)*(full(W)*v)
+    @test_approx_eq W[1:3,1:3]*v[1:3] full(W)[1:3,1:3]*v[1:3]
+
+    if elty != Int
+        @test_approx_eq inv(W)*v inv(full(W))*v
+        @test_approx_eq W\v inv(full(W))*v        
+        @test_approx_eq liftFactor(W)(v) inv(W)*v
+    end
+
+end
+
+
+for elty in (Float32, Float64, Complex64, Complex128, Int)
+
+    elty = Float64
+
+    a = rand(n); B = rand(n,2); D = rand(2,2); v = rand(n)
+
+    if elty == Int
+        v = rand(1:100, n)
+        
+        a1 = rand(1:100, n, 2)
+        B1 = rand(1:100, 2, n)
+        D1 = rand(1:100, 2, 2)
+
+        a2 = rand(1:100, n, 2)
+        B2 = rand(1:100, 2, n)
+        D2 = rand(1:100, 2, 2)
+    else
+        v = convert(Vector{elty}, a)
+
+        a1 = convert(Vector{elty}, a)
+        B1 = convert(Matrix{elty}, B)
+        D1 = convert(Matrix{elty}, D)
+
+        a2 = convert(Vector{elty}, a)
+        B2 = convert(Matrix{elty}, B)
+        D2 = convert(Matrix{elty}, D)
+    end
+
+    ε = eps(abs2(float(one(elty))))
+    
+    # Woodbury
+    A1 = Diagonal(a1)
+    A2 = Diagonal(a2)
+
+    W1 = SymWoodbury(A1, B1, D1)
+    W2 = SymWoodbury(A2, B2, D2)
+
+    @test_approx_eq (W1 + W2)*v (full(W1) + full(W2))*v
+    @test_approx_eq (full(W1) + W2)*v (full(W1) + full(W2))*v
+    @test_approx_eq (W1 + full(W2))*v (full(W1) + full(W2))*v
+
+end
+
+# Sparse U and D
+
+A = Diagonal(rand(n))
+B = sprandn(n,2,1.)
+D = sprandn(2,2,1.)
+W = SymWoodbury(A, B, D)
+v = randn(n)
+V = randn(n,1)
+
+@test size(W) == (n,n)
+@test size(W,1) == n
+@test size(W,2) == n
+
+@test_approx_eq inv(W)*v inv(full(W))*v
+@test_approx_eq (2*W)*v 2*(W*v)
+@test_approx_eq (W'W)*v full(W)*(full(W)*v)
+@test_approx_eq (W*W)*v full(W)*(full(W)*v)
+@test_approx_eq (W*W')*v full(W)*(full(W)*v)
+@test_approx_eq liftFactor(W)(v) inv(W)*v
+
+@test_approx_eq inv(W)*V inv(full(W))*V
+@test_approx_eq (2*W)*V 2*(W*V)
+@test_approx_eq (W'W)*V full(W)*(full(W)*V)
+@test_approx_eq (W*W)*V full(W)*(full(W)*V)
+@test_approx_eq (W*W')*V full(W)*(full(W)*V)
+
+# # Mismatched sizes
+# @test_throws DimensionMismatch Woodbury(rand(5,5),rand(5,2),rand(2,3),rand(3,5))
+# @test_throws DimensionMismatch Woodbury(rand(5,5),rand(5,2),rand(3,3),rand(2,5))


### PR DESCRIPTION
HI Tim! 

I am submitting this rather large pull request for your review on @tkelman 's suggestion - this module adds a new type, `SymWoodbury`, which is an optimized version of `Woodbury` for symmetric matrices. This module was created for a conic interior point solver which makes heavy use of matrices of this sort.

This package was a unregistered standalone package before
https://github.com/MPF-Optimization-Laboratory/SymWoodburyMatrices.jl
but it seems reasonable to add this functionality into this library.

I have tried my best to write this in idiomatic Julia, but I welcome your suggestions/review. 

Gabe
