### PR TITLE
test 0.4 and 0.5 separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: true


### PR DESCRIPTION
0.4 still supported according to REQUIRE