### PR TITLE
Fix errors and deprecations on v0.7 (and drop v0.4 and v0.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: true

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
-Compat 0.7.19
+julia 0.6
+Compat 0.49

--- a/src/SymWoodburyMatrices.jl
+++ b/src/SymWoodburyMatrices.jl
@@ -36,7 +36,7 @@ function SymWoodbury(A, B::AbstractVector{T}, D::T) where {T}
     SymWoodbury{T,typeof(A),typeof(B),typeof(D)}(A,B,D)
 end
 
-convert(::Type{W}, O::SymWoodbury) where {W<:Woodbury}= Woodbury(O.A, O.B, O.D, O.B')
+convert(::Type{W}, O::SymWoodbury) where {W<:Woodbury} = Woodbury(O.A, O.B, O.D, O.B')
 
 inv_invD_BtX(invD, B, X) = inv(invD - B'*X);
 inv_invD_BtX(invD, B::AbstractVector, X) = inv(invD - vecdot(B,X));
@@ -130,10 +130,8 @@ function plusBDBtx!(o, B::Array{Float64,1}, d::Real, x::Union{Array{Float64,2}, 
   end
 end
 
-*(O1::Adjoint{T, <:SymWoodbury{T}}, x::AbstractVector{T}) where {T} = parent(O1) * x
-*(O1::Adjoint{T, <:SymWoodbury{T}}, x::AbstractMatrix) where {T} = parent(O1) * x
-# Base.Ac_mul_B(O1::SymWoodbury{T}, x::AbstractVector{T}) where {T} = O1*x
-# Base.Ac_mul_B(O1::SymWoodbury, x::AbstractMatrix) = O1*x
+Base.Ac_mul_B(O1::SymWoodbury{T}, x::AbstractVector{T}) where {T} = O1*x
+Base.Ac_mul_B(O1::SymWoodbury, x::AbstractMatrix) = O1*x
 
 +(O::SymWoodbury, M::SymWoodbury)    = SymWoodbury(O.A + M.A, [O.B M.B],
                                                    cat([1,2],O.D,M.D) );
@@ -190,6 +188,6 @@ Compat.SparseArrays.sparse(O::SymWoodbury) = sparse(Matrix(O))
 
 # returns a pointer to the original matrix, this is consistent with the
 # behavior of Symmetric in Base.
-Base.ctranspose(O::SymWoodbury) = O
+Compat.adjoint(O::SymWoodbury) = O
 
 Compat.LinearAlgebra.det(W::SymWoodbury) = det(convert(Woodbury, W))

--- a/src/WoodburyMatrices.jl
+++ b/src/WoodburyMatrices.jl
@@ -3,8 +3,9 @@ isdefined(Base, :__precompile__) && __precompile__()
 module WoodburyMatrices
 
 using Compat
-
-import Base: *, \, A_ldiv_B!, convert, copy, det, full, show, similar, size
+using Compat.LinearAlgebra
+import Compat.LinearAlgebra: A_ldiv_B!, det
+import Base: *, \, convert, copy, show, similar, size
 
 export Woodbury, SymWoodbury, liftFactor
 
@@ -13,7 +14,7 @@ export Woodbury, SymWoodbury, liftFactor
 `W = Woodbury(A, U, C, V)` creates a matrix `W` identical to `A + U*C*V` whose inverse will be calculated using
 the Woodbury matrix identity.
 """
-type Woodbury{T,AType,UType,VType,CType,CpType} <: AbstractMatrix{T}
+mutable struct Woodbury{T,AType,UType,VType,CType,CpType} <: AbstractMatrix{T}
     A::AType
     U::UType
     C::CType
@@ -25,7 +26,7 @@ type Woodbury{T,AType,UType,VType,CType,CpType} <: AbstractMatrix{T}
     tmpk2::Vector{T}
 end
 
-function Woodbury{T}(A, U::AbstractMatrix{T}, C, V::AbstractMatrix{T})
+function Woodbury(A, U::AbstractMatrix{T}, C, V::AbstractMatrix{T}) where {T}
     N = size(A, 1)
     k = size(U, 2)
     if size(A, 2) != N || size(U, 1) != N || size(V, 1) != k || size(V, 2) != N
@@ -38,16 +39,16 @@ function Woodbury{T}(A, U::AbstractMatrix{T}, C, V::AbstractMatrix{T})
     end
     Cp = inv(inv(C) + V*(A\U))
     # temporary space for allocation-free solver
-    tmpN1 = Array{T,1}(N)
-    tmpN2 = Array{T,1}(N)
-    tmpk1 = Array{T,1}(k)
-    tmpk2 = Array{T,1}(k)
+    tmpN1 = Array{T,1}(uninitialized, N)
+    tmpN2 = Array{T,1}(uninitialized, N)
+    tmpk1 = Array{T,1}(uninitialized, k)
+    tmpk2 = Array{T,1}(uninitialized, k)
     # don't copy A, it could be huge
     Woodbury{T,typeof(A),typeof(U),typeof(V),typeof(C),typeof(Cp)}(A, copy(U), copy(C), Cp, copy(V), tmpN1, tmpN2, tmpk1, tmpk2)
 end
 
-Woodbury{T}(A, U::Vector{T}, C, V::Matrix{T}) = Woodbury(A, reshape(U, length(U), 1), C, V)
-@static if isdefined(:RowVector)    Woodbury(A, U::AbstractVector, C, V::RowVector) = Woodbury(A, U, C, Matrix(V)) end
+Woodbury(A, U::Vector{T}, C, V::Matrix{T}) where {T} = Woodbury(A, reshape(U, length(U), 1), C, V)
+Woodbury(A, U::AbstractVector, C, V::RowVector) = Woodbury(A, U, C, Matrix(V))
 
 size(W::Woodbury) = size(W.A)
 
@@ -66,8 +67,8 @@ function show(io::IO, W::Woodbury)
     Base.print_matrix(io, W.V)
 end
 
-full{T}(W::Woodbury{T}) = convert(Matrix{T}, W)
-convert{T}(::Type{Matrix{T}}, W::Woodbury{T}) = full(W.A) + W.U*W.C*W.V
+Base.Matrix(W::Woodbury{T}) where {T} = convert(Matrix{T}, W)
+convert(::Type{Matrix{T}}, W::Woodbury{T}) where {T} = Matrix(W.A) + W.U*W.C*W.V
 
 copy(W::Woodbury) = Woodbury(W.A, W.U, W.C, W.V)
 
@@ -84,13 +85,13 @@ det(W::Woodbury)=det(W.A)*det(W.C)/det(W.Cp)
 
 function A_ldiv_B!(W::Woodbury, B::AbstractVector)
     length(B) == size(W, 1) || throw(DimensionMismatch("Vector length $(length(B)) must match matrix size $(size(W,1))"))
-    copy!(W.tmpN1, B)
+    copyto!(W.tmpN1, B)
     Alu = lufact(W.A) # Note. This makes an allocation (unless A::LU). Alternative is to destroy W.A.
-    A_ldiv_B!(Alu, W.tmpN1)
-    A_mul_B!(W.tmpk1, W.V, W.tmpN1)
-    A_mul_B!(W.tmpk2, W.Cp, W.tmpk1)
-    A_mul_B!(W.tmpN2, W.U, W.tmpk2)
-    A_ldiv_B!(Alu, W.tmpN2)
+    ldiv!(Alu, W.tmpN1)
+    mul!(W.tmpk1, W.V, W.tmpN1)
+    mul!(W.tmpk2, W.Cp, W.tmpk1)
+    mul!(W.tmpN2, W.U, W.tmpk2)
+    ldiv!(Alu, W.tmpN2)
     for i = 1:length(W.tmpN2)
         @inbounds B[i] = W.tmpN1[i] - W.tmpN2[i]
     end
@@ -127,7 +128,7 @@ julia> r*c*v - Diagonal([2.0, 3.0, 4.0])
 ```
 
 """
-function sparse_factors{T}(::Type{T}, n::Int, args::@compat(Tuple{Int, Int, Any})...)
+function sparse_factors(::Type{T}, n::Int, args::@compat(Tuple{Int, Int, Any})...) where {T}
     m = length(args)
     rows = spzeros(T, n, m)
     cols = spzeros(T, m, n)

--- a/src/WoodburyMatrices.jl
+++ b/src/WoodburyMatrices.jl
@@ -4,8 +4,14 @@ module WoodburyMatrices
 
 using Compat
 using Compat.LinearAlgebra
-import Compat.LinearAlgebra: A_ldiv_B!, det
+import Compat.LinearAlgebra: det, A_ldiv_B!
 import Base: *, \, convert, copy, show, similar, size
+
+# TOOD: remove these definitions once Compat.jl catches up
+@static if VERSION <= v"0.7.0-DEV.3185"
+    const ldiv! = A_ldiv_B!
+    const mul! = A_mul_B!
+end
 
 export Woodbury, SymWoodbury, liftFactor
 
@@ -51,7 +57,11 @@ function Woodbury(A, U::AbstractMatrix{T}, C, V::AbstractMatrix{T}) where {T}
 end
 
 Woodbury(A, U::Vector{T}, C, V::Matrix{T}) where {T} = Woodbury(A, reshape(U, length(U), 1), C, V)
-Woodbury(A, U::AbstractVector, C, V::Adjoint) = Woodbury(A, U, C, Matrix(V))
+@static if VERSION <= v"0.7.0-DEV.3040"
+    Woodbury(A, U::AbstractVector, C, V::RowVector) = Woodbury(A, U, C, Matrix(V))
+else
+    Woodbury(A, U::AbstractVector, C, V::Adjoint) = Woodbury(A, U, C, Matrix(V))
+end
 
 size(W::Woodbury) = size(W.A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using WoodburyMatrices
+using Compat
 using Compat.LinearAlgebra
 using Compat.Random: srand
 using Compat.SparseArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Compat.Random: srand
 using Compat.SparseArrays
 using Compat.Test
 
-@testset "woodbury matrices" begin
+@testset "WoodburyMatrices" begin
 srand(123)
 n = 5
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using WoodburyMatrices
-using Base.Test
+using Compat.LinearAlgebra
+using Compat.Random: srand
+using Compat.SparseArrays
+using Compat.Test
 
+@testset "woodbury matrices" begin
 srand(123)
 n = 5
 
@@ -14,7 +18,7 @@ U = randn(n,2)
 V = randn(2,n)
 C = randn(2,2)
 
-for elty in (Float32, Float64, Complex64, Complex128, Int)
+for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     if elty == Int
         srand(61516384)
         d = rand(1:100, n)
@@ -44,7 +48,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
 
     # Woodbury
     W = Woodbury(T, U, C, V)
-    F = full(W)
+    F = Matrix(W)
     @test W*v ≈ F*v
     iFv = F\v
     @test norm(W\v - iFv)/norm(iFv) <= n*cond(F)*ε # Revisit. Condition number is wrong
@@ -66,7 +70,7 @@ U = sprandn(n,2,0.2)
 V = sprandn(2,n,0.2)
 C = randn(2,2)
 W = Woodbury(T, U, C, V)
-F = full(W)
+F = Matrix(W)
 
 v = randn(n)
 ε = eps()
@@ -82,7 +86,7 @@ U = rand(n)
 C = 2.3
 V = rand(1,n)
 W = Woodbury(T, U, C, V)
-F = full(W)
+F = Matrix(W)
 
 v = randn(n)
 ε = eps()
@@ -114,3 +118,4 @@ for i in 1:5  # repeat 5 times
 end
 
 include("runtests_sym.jl")
+end

--- a/test/runtests_sym.jl
+++ b/test/runtests_sym.jl
@@ -5,7 +5,7 @@ using WoodburyMatrices
 srand(123)
 n = 5
 
-for elty in (Float32, Float64, ComplexF32, ComplexF64, Int), AMat in (diagm,)
+for elty in (Float32, Float64, ComplexF32, ComplexF64, Int), AMat in (x -> Matrix(Diagonal(x)),)
 
     elty = Float64
 
@@ -38,8 +38,8 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int), AMat in (diagm,)
         @test W[1:3,1:3]*v[1:3] ≈ Matrix(W)[1:3,1:3]*v[1:3]
         @test sparse(W) ≈ Matrix(W)
         @test W === W'
-        @test W*eye(n) ≈ Matrix(W)
-        @test W'*eye(n) ≈ Matrix(W)
+        @test W*Matrix(1.0I, n, n) ≈ Matrix(W)
+        @test W'*Matrix(1.0I, n, n) ≈ Matrix(W)
 
         Z = randn(n,n)
         @test Matrix(W*Z) ≈ Matrix(W)*Z
@@ -54,7 +54,7 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int), AMat in (diagm,)
             @test (W*W')*v ≈ Matrix(W)*(Matrix(W)*v)
             @test W[1:3,1:3]*v[1:3] ≈ Matrix(W)[1:3,1:3]*v[1:3]
             @test Matrix(WoodburyMatrices.conjm(W, R)) ≈ R*Matrix(W)*R'
-            @test Matrix((copy(W)'W)*v) ≈ Matrix(W)*(Matrix(W)*v)
+            @test Matrix(copy(W)'W)*v ≈ Matrix(W)*(Matrix(W)*v)
             @test Matrix(W + A) ≈ Matrix(W)+Matrix(A)
             @test Matrix(A + W) ≈ Matrix(W)+Matrix(A)
         end
@@ -77,7 +77,7 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int), AMat in (diagm,)
 end
 
 
-for elty in (Float32, Float64, Complex64, Complex128, Int)
+for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
 
     elty = Float64
 
@@ -109,8 +109,8 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     ε = eps(abs2(float(one(elty))))
 
     # Woodbury
-    A1 = diagm(a1)
-    A2 = diagm(a2)
+    A1 = Matrix(Diagonal((a1)))
+    A2 = Matrix(Diagonal((a2)))
 
     W1 = SymWoodbury(A1, B1, D1)
     W2 = SymWoodbury(A2, B2, D2)
@@ -121,7 +121,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     for (W1, W2) = ((W1,W2), (W1r, W2), (W1, W2r), (W1r,W2r))
         @test (W1 + W2)*v ≈ (Matrix(W1) + Matrix(W2))*v
         @test (Matrix(W1) + W2)*v ≈ (Matrix(W1) + Matrix(W2))*v
-        @test (W1 + 2*diagm(a1))*v ≈ (Matrix(W1) + Matrix(2*diagm(a1)))*v
+        @test (W1 + 2*Matrix(Diagonal((a1))))*v ≈ (Matrix(W1) + Matrix(2*Matrix(Diagonal((a1)))))*v
         @test_throws MethodError W1*W2
     end
 
@@ -129,7 +129,7 @@ end
 
 # Sparse U and D
 
-A = diagm(rand(n))
+A = Matrix(Diagonal((rand(n))))
 B = sprandn(n,2,1.)
 D = sprandn(2,2,1.)
 W = SymWoodbury(A, B, D)

--- a/test/runtests_sym.jl
+++ b/test/runtests_sym.jl
@@ -1,11 +1,11 @@
-using Base.Test
+using Compat
+using Compat.Test
 using WoodburyMatrices
-using Compat:view
 
 srand(123)
 n = 5
 
-for elty in (Float32, Float64, Complex64, Complex128, Int), AMat in (diagm,)
+for elty in (Float32, Float64, ComplexF32, ComplexF64, Int), AMat in (diagm,)
 
     elty = Float64
 
@@ -29,47 +29,47 @@ for elty in (Float32, Float64, Complex64, Complex128, Int), AMat in (diagm,)
     # Woodbury
     for W in (SymWoodbury(A, B, D), SymWoodbury(A, B[:,1][:], 2.))
 
-        F = full(W)
+        F = Matrix(W)
         @test (2*W)*v ≈ 2*(W*v)
         @test W'*v ≈ W*v
-        @test (W'W)*v ≈ full(W)*(full(W)*v)
-        @test (W*W)*v ≈ full(W)*(full(W)*v)
-        @test (W*W')*v ≈ full(W)*(full(W)*v)
-        @test W[1:3,1:3]*v[1:3] ≈ full(W)[1:3,1:3]*v[1:3]
-        @test sparse(W) ≈ full(W)
+        @test (W'W)*v ≈ Matrix(W)*(Matrix(W)*v)
+        @test (W*W)*v ≈ Matrix(W)*(Matrix(W)*v)
+        @test (W*W')*v ≈ Matrix(W)*(Matrix(W)*v)
+        @test W[1:3,1:3]*v[1:3] ≈ Matrix(W)[1:3,1:3]*v[1:3]
+        @test sparse(W) ≈ Matrix(W)
         @test W === W'
-        @test W*eye(n) ≈ full(W)
-        @test W'*eye(n) ≈ full(W)
+        @test W*eye(n) ≈ Matrix(W)
+        @test W'*eye(n) ≈ Matrix(W)
 
         Z = randn(n,n)
-        @test full(W*Z) ≈ full(W)*Z
+        @test Matrix(W*Z) ≈ Matrix(W)*Z
 
         R = rand(n,n)
 
         for v = (rand(n, 1), view(rand(n,1), 1:n), view(rand(n,2),1:n,1:2))
             @test (2*W)*v ≈ 2*(W*v)
             @test (W*2)*v ≈ 2*(W*v)
-            @test (W'W)*v ≈ full(W)*(full(W)*v)
-            @test (W*W)*v ≈ full(W)*(full(W)*v)
-            @test (W*W')*v ≈ full(W)*(full(W)*v)
-            @test W[1:3,1:3]*v[1:3] ≈ full(W)[1:3,1:3]*v[1:3]
-            @test full(WoodburyMatrices.conjm(W, R)) ≈ R*full(W)*R'
-            @test full((copy(W)'W)*v) ≈ full(W)*(full(W)*v)
-            @test full(W + A) ≈ full(W)+full(A)
-            @test full(A + W) ≈ full(W)+full(A)
+            @test (W'W)*v ≈ Matrix(W)*(Matrix(W)*v)
+            @test (W*W)*v ≈ Matrix(W)*(Matrix(W)*v)
+            @test (W*W')*v ≈ Matrix(W)*(Matrix(W)*v)
+            @test W[1:3,1:3]*v[1:3] ≈ Matrix(W)[1:3,1:3]*v[1:3]
+            @test Matrix(WoodburyMatrices.conjm(W, R)) ≈ R*Matrix(W)*R'
+            @test Matrix((copy(W)'W)*v) ≈ Matrix(W)*(Matrix(W)*v)
+            @test Matrix(W + A) ≈ Matrix(W)+Matrix(A)
+            @test Matrix(A + W) ≈ Matrix(W)+Matrix(A)
         end
 
         v = rand(n,1)
         W2 = convert(Woodbury, W)
-        @test full(W2) ≈ full(W)
+        @test Matrix(W2) ≈ Matrix(W)
 
         if elty != Int
-            @test inv(W)*v ≈ inv(full(W))*v
-            @test W\v ≈ inv(full(W))*v
+            @test inv(W)*v ≈ inv(Matrix(W))*v
+            @test W\v ≈ inv(Matrix(W))*v
             @test liftFactor(W)(v) ≈ inv(W)*v
             @test WoodburyMatrices.partialInv(W)[1] ≈ inv(W).B
             @test WoodburyMatrices.partialInv(W)[2] ≈ inv(W).D
-            @test det(W) ≈ det(full(W))
+            @test det(W) ≈ det(Matrix(W))
         end
 
     end
@@ -119,9 +119,9 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     W2r = SymWoodbury(A2, B2[:,1][:], 3.)
 
     for (W1, W2) = ((W1,W2), (W1r, W2), (W1, W2r), (W1r,W2r))
-        @test (W1 + W2)*v ≈ (full(W1) + full(W2))*v
-        @test (full(W1) + W2)*v ≈ (full(W1) + full(W2))*v
-        @test (W1 + 2*diagm(a1))*v ≈ (full(W1) + full(2*diagm(a1)))*v
+        @test (W1 + W2)*v ≈ (Matrix(W1) + Matrix(W2))*v
+        @test (Matrix(W1) + W2)*v ≈ (Matrix(W1) + Matrix(W2))*v
+        @test (W1 + 2*diagm(a1))*v ≈ (Matrix(W1) + Matrix(2*diagm(a1)))*v
         @test_throws MethodError W1*W2
     end
 
@@ -140,18 +140,18 @@ V = randn(n,1)
 @test size(W,1) == n
 @test size(W,2) == n
 
-@test inv(W)*v ≈ inv(full(W))*v
+@test inv(W)*v ≈ inv(Matrix(W))*v
 @test (2*W)*v ≈ 2*(W*v)
-@test (W'W)*v ≈ full(W)*(full(W)*v)
-@test (W*W)*v ≈ full(W)*(full(W)*v)
-@test (W*W')*v ≈ full(W)*(full(W)*v)
+@test (W'W)*v ≈ Matrix(W)*(Matrix(W)*v)
+@test (W*W)*v ≈ Matrix(W)*(Matrix(W)*v)
+@test (W*W')*v ≈ Matrix(W)*(Matrix(W)*v)
 @test liftFactor(W)(v) ≈ inv(W)*v
 
-@test inv(W)*V ≈ inv(full(W))*V
+@test inv(W)*V ≈ inv(Matrix(W))*V
 @test (2*W)*V ≈ 2*(W*V)
-@test (W'W)*V ≈ full(W)*(full(W)*V)
-@test (W*W)*V ≈ full(W)*(full(W)*V)
-@test (W*W')*V ≈ full(W)*(full(W)*V)
+@test (W'W)*V ≈ Matrix(W)*(Matrix(W)*V)
+@test (W*W)*V ≈ Matrix(W)*(Matrix(W)*V)
+@test (W*W')*V ≈ Matrix(W)*(Matrix(W)*V)
 
 # Mismatched sizes
 @test_throws DimensionMismatch SymWoodbury(rand(5,5),rand(5,2),rand(2,3))


### PR DESCRIPTION
With these changes, I get the tests passing (with no warnings) on v0.6 and v0.7. I'm still pretty new to the big linalg changes in v0.7, so I'd appreciate a review of this if you have some time. 