### PR TITLE
define \(::AbstractWoodbury, ::Diagonal)

### DIFF
--- a/src/WoodburyMatrices.jl
+++ b/src/WoodburyMatrices.jl
@@ -56,10 +56,13 @@ end
 
 # Division
 
-function \(W::AbstractWoodbury, R::AbstractMatrix)
+function _ldiv(W::AbstractWoodbury, R::AbstractMatrix)
     AinvR = W.A\R
     return AinvR - W.A\(W.U*(W.Cp*(W.V*AinvR)))
 end
+
+\(W::AbstractWoodbury, R::AbstractMatrix) = _ldiv(W, R)
+\(W::AbstractWoodbury, D::Diagonal) = _ldiv(W, D)
 
 ldiv!(W::AbstractWoodbury, B::AbstractVector) = ldiv!(B, W, B)
 

--- a/test/symwoodbury.jl
+++ b/test/symwoodbury.jl
@@ -132,6 +132,7 @@ B = sprandn(n,2,1.)
 D = sprandn(2,2,1.); D = (D + D')/2
 W = SymWoodbury(A, B, D)
 v = randn(n)
+vdiag = Diagonal(v)
 V = randn(n,1)
 
 @test size(W) == (n,n)
@@ -144,6 +145,10 @@ V = randn(n,1)
 @test (W*W)*v ≈ Matrix(W)*(Matrix(W)*v)
 @test (W*W')*v ≈ Matrix(W)*(Matrix(W)*v)
 @test liftFactor(W)(v) ≈ inv(W)*v
+
+@test inv(W)*vdiag ≈ W\vdiag
+@test W\vdiag ≈ W\Matrix(vdiag)
+@test inv(W)*vdiag ≈ inv(Matrix(W))*vdiag
 
 @test inv(W)*V ≈ inv(Matrix(W))*V
 @test (2*W)*V ≈ 2*(W*V)

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -74,6 +74,10 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     iFv = F\v
     @test norm(W\v - iFv)/norm(iFv) <= n*cond(F)*ε # Revisit. Condition number is wrong
 
+    # Check division with diagonal matrix
+    iFvmat = F\Diagonal(v)
+    @test norm(W\Diagonal(v) - iFvmat)/norm(iFvmat) <= n*cond(F)*ε # Revisit. Condition number is wrong
+
     # Factorization for A
     W = Woodbury(lu(T), U, C, V)
     F = Matrix(W)


### PR DESCRIPTION
Hello Tim,

This pull request is an attempt to fix the following error.

```julia
julia> using WoodburyMatrices
julia> using LinearAlgebra
julia> n = 4
julia> A = Diagonal(rand(n))
julia> B = randn(n,n)
julia> D = Symmetric(randn(n,n))
julia> W = SymWoodbury(A, B, D)
julia> E = Diagonal(randn(n))
julia> W\E
ERROR: MethodError: \(::SymWoodbury{Float64,Diagonal{Float64,Array{Float64,1}},Array{Float64,2},Symmetric{Float64,Array{Float64,2}},Array{Float64,2}}, ::Diagonal{Float64,Array{Float64,1}}) is ambiguous. Candidates:
  \(F::Factorization, D::Diagonal) in LinearAlgebra at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.3/LinearAlgebra/src/diagonal.jl:468
  \(W::AbstractWoodbury, R::AbstractArray{T,2} where T) in WoodburyMatrices at /Users/nikos/.julia/dev/WoodburyMatrices/src/WoodburyMatrices.jl:60
Possible fix, define
  \(::AbstractWoodbury, ::Diagonal)
```