### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WoodburyMatrices
 
-[![Build Status](https://travis-ci.org/timholy/WoodburyMatrices.jl.svg?branch=master)](https://travis-ci.org/timholy/WoodburyMatrices.jl)
-[![Coverage Status](https://coveralls.io/repos/timholy/WoodburyMatrices.jl/badge.svg)](https://coveralls.io/r/timholy/WoodburyMatrices.jl)
+[![Build Status](https://github.com/JuliaLinearAlgebra/WoodburyMatrices.jl/workflows/CI/badge.svg)](https://github.com/JuliaLinearAlgebra/WoodburyMatrices.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![Coverage Status](http://codecov.io/github/JuliaLinearAlgebra/WoodburyMatrices.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaLinearAlgebra/WoodburyMatrices.jl?branch=master)
 
 This package provides support for the [Woodbury matrix identity](http://en.wikipedia.org/wiki/Woodbury_matrix_identity) for the Julia programming language.  This is a generalization of the [Sherman-Morrison formula](http://en.wikipedia.org/wiki/Sherman%E2%80%93Morrison_formula). Note that the Woodbury matrix identity is notorious for floating-point roundoff errors, so be prepared for a certain amount of inaccuracy in the result.
 


### PR DESCRIPTION
These now point to JuliaLinearAlgebra and show GitHub Actions and Codecov rather than Travis and Coveralls.