### PR TITLE
Thread-safety: disable internal storage by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ using WoodburyMatrices
 W = SymWoodbury(A, B, D)
 ```
 creates a `SymWoodbury` matrix, a symmetric version of a Woodbury matrix representing `A + B*D*B'`. In addition to the features above, `SymWoodbury` also supports "squaring" `W*W`.
+
+## Efficiency and thread-safety
+
+(Sym)Woodbury allocates internal temporary storage for intermediate results in `W*v` and `W\v` where `v` is a vector.
+This eliminates memory allocation for these common operations.
+
+However, using the same `W` across multiple threads can lead to race conditions. In such cases, construct `W` with
+the keyword option `allocatetmp=false` to disable this optimization.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ creates a `SymWoodbury` matrix, a symmetric version of a Woodbury matrix represe
 
 ## Efficiency and thread-safety
 
-(Sym)Woodbury allocates internal temporary storage for intermediate results in `W*v` and `W\v` where `v` is a vector.
+If passed the keyword argument `allocatetmp=true`, (Sym)Woodbury allocates internal temporary storage for intermediate results in `W*v` and `W\v` where `v` is a vector.
 This eliminates memory allocation for these common operations.
 
-However, using the same `W` across multiple threads can lead to race conditions. In such cases, construct `W` with
-the keyword option `allocatetmp=false` to disable this optimization.
+However, using the same `W` across multiple threads can lead to race conditions. Hence, this optimization is opt-in and should only be used if you know it is safe.

--- a/src/symwoodbury.jl
+++ b/src/symwoodbury.jl
@@ -13,7 +13,7 @@ struct SymWoodbury{T,AType,BType,DType,DpType} <: AbstractWoodbury{T}
 end
 
 """
-    W = SymWoodbury(A, B, D; allocatetmp::Bool=true)
+    W = SymWoodbury(A, B, D; allocatetmp::Bool=false)
 
 Represent a matrix of the form `W = A + BDBᵀ`, where `A` and `D` are symmetric.
 Equations `Wx = b` will be solved using the
@@ -28,7 +28,7 @@ or factorization.
 
 See also [Woodbury](@ref), where `allocatetmp` is explained.
 """
-function SymWoodbury(A, B::AbstractVecOrMat, D; allocatetmp::Bool=true)
+function SymWoodbury(A, B::AbstractVecOrMat, D; allocatetmp::Bool=false)
     @noinline throwdmm(B, D, A) = throw(DimensionMismatch("Sizes of B ($(size(B))) and/or D ($(size(D))) are inconsistent with A ($(size(A)))"))
 
     n = size(A, 1)

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -14,7 +14,7 @@ struct Woodbury{T,AType,UType,VType,CType,CpType} <: AbstractWoodbury{T}
 end
 
 """
-    W = Woodbury(A, U, C, V; allocatetmp::Bool=true)
+    W = Woodbury(A, U, C, V; allocatetmp::Bool=false)
 
 Represent a matrix `W = A + UCV`.
 Equations `Wx = b` will be solved using the
@@ -27,14 +27,14 @@ If `allocatetmp` is true, temporary storage used for intermediate steps in
 multiplication and division will be allocated.
 
 !!! warning
-    If you'll use the same `W` in multiple threads, you should set `allocatetmp=false`
+    If you'll use the same `W` in multiple threads, you should use `allocatetmp=false`
     or risk data races.
 
 
 See also [SymWoodbury](@ref).
 
 """
-function Woodbury(A, U::AbstractMatrix, C, V::AbstractMatrix; allocatetmp::Bool=true)
+function Woodbury(A, U::AbstractMatrix, C, V::AbstractMatrix; allocatetmp::Bool=false)
     @noinline throwdmm1(U, V, A) = throw(DimensionMismatch("Sizes of U ($(size(U))) and/or V ($(size(V))) are inconsistent with A ($(size(A)))"))
     @noinline throwdmm2(k) = throw(DimensionMismatch("C should be $(k)x$(k)"))
 

--- a/test/symwoodbury.jl
+++ b/test/symwoodbury.jl
@@ -26,7 +26,7 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     ε = eps(abs2(float(one(elty))))
     A = Diagonal(a)
 
-    for W in (SymWoodbury(A, B, D), SymWoodbury(A, B[:,1][:], 2.))
+    for W in (SymWoodbury(A, B, D), SymWoodbury(A, B, D; allocatetmp=false), SymWoodbury(A, B[:,1][:], 2.))
 
         @test issymmetric(W)
         F = Matrix(W)

--- a/test/symwoodbury.jl
+++ b/test/symwoodbury.jl
@@ -26,7 +26,7 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     ε = eps(abs2(float(one(elty))))
     A = Diagonal(a)
 
-    for W in (SymWoodbury(A, B, D), SymWoodbury(A, B, D; allocatetmp=false), SymWoodbury(A, B[:,1][:], 2.))
+    for W in (SymWoodbury(A, B, D), SymWoodbury(A, B, D; allocatetmp=true), SymWoodbury(A, B[:,1][:], 2.))
 
         @test issymmetric(W)
         F = Matrix(W)

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -39,7 +39,7 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     T = Tridiagonal(dl, d, du)
 
     # Matrix for A
-    for W in (Woodbury(T, U, C, V), Woodbury(T, U, C, V; allocatetmp=false))
+    for W in (Woodbury(T, U, C, V), Woodbury(T, U, C, V; allocatetmp=true))
         @test size(W, 1) == n
         @test size(W) == (n, n)
         @test axes(W) === (Base.OneTo(n), Base.OneTo(n))

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -39,36 +39,37 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     T = Tridiagonal(dl, d, du)
 
     # Matrix for A
-    W = Woodbury(T, U, C, V)
-    @test size(W, 1) == n
-    @test size(W) == (n, n)
-    @test axes(W) === (Base.OneTo(n), Base.OneTo(n))
-    @test axes(W, 1) === Base.OneTo(n)
-    F = Matrix(W)
-    @test F ≈ T + U*C*V
-    @test Array(W) == Matrix(W)
-    if elty <: Real
-        @test eltype(Matrix{Float64}(W)) === Float64
-        @test eltype(Array{Float64}(W)) === Float64
-    end
-    @test W*v ≈ F*v
-    iFv = F\v
-    @test norm(W\v - iFv)/norm(iFv) <= n*cond(F)*ε # Revisit. Condition number is wrong
-    @test norm(inv(W)*v - iFv)/norm(iFv) <= n*cond(F)*ε
-    @test norm(diag(W) - diag(F)) <= n*cond(F)*ε # haven't thought about this error bound
-    @test abs((det(W) - det(F))/det(F)) <= n*cond(F)*ε # Revisit. Condition number is wrong
-    iWv = similar(iFv)
-    if elty != Int
-        iWv = ldiv!(W, copy(v))
-        @test iWv ≈ iFv
-    end
-    @test W'*v ≈ F'*v
-    @test transpose(W)*v ≈ transpose(F)*v
-    @test (W + W) \ v ≈ (2*Matrix(W)) \ v
-    # Test a method used for ambiguity resolution
-    if elty<:Union{Float32, Float64}
-        R = randn(Complex{elty}, n, 2)
-        @test W \ R ≈ Matrix(W) \ R
+    for W in (Woodbury(T, U, C, V), Woodbury(T, U, C, V; allocatetmp=false))
+        @test size(W, 1) == n
+        @test size(W) == (n, n)
+        @test axes(W) === (Base.OneTo(n), Base.OneTo(n))
+        @test axes(W, 1) === Base.OneTo(n)
+        F = Matrix(W)
+        @test F ≈ T + U*C*V
+        @test Array(W) == Matrix(W)
+        if elty <: Real
+            @test eltype(Matrix{Float64}(W)) === Float64
+            @test eltype(Array{Float64}(W)) === Float64
+        end
+        @test W*v ≈ F*v
+        iFv = F\v
+        @test norm(W\v - iFv)/norm(iFv) <= n*cond(F)*ε # Revisit. Condition number is wrong
+        @test norm(inv(W)*v - iFv)/norm(iFv) <= n*cond(F)*ε
+        @test norm(diag(W) - diag(F)) <= n*cond(F)*ε # haven't thought about this error bound
+        @test abs((det(W) - det(F))/det(F)) <= n*cond(F)*ε # Revisit. Condition number is wrong
+        iWv = similar(iFv)
+        if elty != Int
+            iWv = ldiv!(W, copy(v))
+            @test iWv ≈ iFv
+        end
+        @test W'*v ≈ F'*v
+        @test transpose(W)*v ≈ transpose(F)*v
+        @test (W + W) \ v ≈ (2*Matrix(W)) \ v
+        # Test a method used for ambiguity resolution
+        if elty<:Union{Float32, Float64}
+            R = randn(Complex{elty}, n, 2)
+            @test W \ R ≈ Matrix(W) \ R
+        end
     end
 
     Tsym = SymTridiagonal(d, du)


### PR DESCRIPTION
The README now describes optimizations and the issues they cause for thread-safety. The constructor now defaults to avoiding these optimizations, but allows them to be turned on with `allocatetmp=true`.