### PR TITLE
Allow passing in `allocs` to Woodbury and SymWoodbury

### DIFF
--- a/src/WoodburyMatrices.jl
+++ b/src/WoodburyMatrices.jl
@@ -85,7 +85,8 @@ function _ldiv!(dest, W::AbstractWoodbury, A::Union{Factorization,Diagonal}, B)
         mul!(W.tmpk1, W.V, W.tmpN1)
         mul!(W.tmpk2, W.Cp, W.tmpk1)
         mul!(W.tmpN2, W.U, W.tmpk2)
-        ldiv!(A, W.tmpN2)
+        W.tmpN3 .= W.tmpN2
+        ldiv!(W.tmpN2, A, W.tmpN3)
         for i in eachindex(W.tmpN2)
             dest[i] = W.tmpN1[i] - W.tmpN2[i]
         end

--- a/src/symwoodbury.jl
+++ b/src/symwoodbury.jl
@@ -47,7 +47,7 @@ function SymWoodbury(A, B::AbstractVecOrMat, D;
     Dp = safeinv(safeinv(D) .+ B'*(A\B))
     # temporary space for allocation-free solver (vector RHS only)
     T = typeof(float(zero(eltype(A)) * zero(eltype(B)) * zero(eltype(D))))
-    tmpN1, tmpN2, tmpN3, tmpk1, tmpk2 = _allocate_tmp(T, allocs, allocatetmp, N, k)
+    tmpN1, tmpN2, tmpN3, tmpk1, tmpk2 = _allocate_tmp(T, allocs, allocatetmp, n, k)
 
     SymWoodbury{T}(A, B, D, Dp, tmpN1, tmpN2, tmpN3, tmpk1, tmpk2)
 end

--- a/src/symwoodbury.jl
+++ b/src/symwoodbury.jl
@@ -9,8 +9,8 @@ struct SymWoodbury{T,AType,BType,DType,DpType} <: AbstractWoodbury{T}
     tmpk1::Union{Vector{T}, Nothing}
     tmpk2::Union{Vector{T}, Nothing}
 
-    SymWoodbury{T}(A, B, D, Dp, tmpN1, tmpN2, tmpk1, tmpk2) where {T} =
-        new{T,typeof(A),typeof(B),typeof(D),typeof(Dp)}(A, B, D, Dp, tmpN1, tmpN2, tmpk1, tmpk2)
+    SymWoodbury{T}(A, B, D, Dp, tmpN1, tmpN2, tmpN3, tmpk1, tmpk2) where {T} =
+        new{T,typeof(A),typeof(B),typeof(D),typeof(Dp)}(A, B, D, Dp, tmpN1, tmpN2, tmpN3, tmpk1, tmpk2)
 end
 
 """

--- a/test/symwoodbury.jl
+++ b/test/symwoodbury.jl
@@ -26,7 +26,17 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     ε = eps(abs2(float(one(elty))))
     A = Diagonal(a)
 
-    for W in (SymWoodbury(A, B, D), SymWoodbury(A, B, D; allocatetmp=true), SymWoodbury(A, B[:,1][:], 2.))
+    n = size(A, 1)
+    k = size(B, 1)
+    tmp_elty = typeof(float(zero(eltype(A)) * zero(eltype(B)) * zero(eltype(D))))
+    allocs = [(Vector{tmp_elty}(undef, n) for i in 1:3)..., (Vector{tmp_elty}(undef, k) for i in 1:2)...]
+
+    for W in (
+        SymWoodbury(A, B, D), 
+        SymWoodbury(A, B, D; allocatetmp=true), 
+        SymWoodbury(A, B, D; allocs), 
+        SymWoodbury(A, B[:,1][:], 2.),
+    )
 
         @test issymmetric(W)
         F = Matrix(W)

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -38,8 +38,16 @@ for elty in (Float32, Float64, ComplexF32, ComplexF64, Int)
     ε = eps(abs2(float(one(elty))))
     T = Tridiagonal(dl, d, du)
 
+    n = size(T, 1)
+    k = size(U, 2)
+    tmp_elty = typeof(float(zero(eltype(T)) * zero(eltype(U)) * zero(eltype(C)) * zero(eltype(V))))
+    allocs = [(Vector{tmp_elty}(undef, n) for i in 1:3)..., (Vector{tmp_elty}(undef, k) for i in 1:2)...]
     # Matrix for A
-    for W in (Woodbury(T, U, C, V), Woodbury(T, U, C, V; allocatetmp=true))
+    for W in (
+        Woodbury(T, U, C, V), 
+        Woodbury(T, U, C, V; allocatetmp=true),
+        Woodbury(T, U, C, V; allocs),
+    )
         @test size(W, 1) == n
         @test size(W) == (n, n)
         @test axes(W) === (Base.OneTo(n), Base.OneTo(n))


### PR DESCRIPTION
If a woodbury matrix is used for few or only a single RHS solve, the cost of allocating temp arrays each time is mildly consequential.

This PR allows passing all allocations as an `allocs` keyword so they can be reused after updates to U/C/V etc. 

At the same time I added an extra tmp variable so that the second `ldiv!` is non-allocating. 

Closes #48

TODO: remove allocations in Cp definition